### PR TITLE
[CHG] Fix typo in exbase persistance class

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -43,7 +43,7 @@ return [
         'tableName' => 'static_languages',
         'properties' => [
             'nameCs' => [
-                'fieldName' => 'cu_name_cs',
+                'fieldName' => 'lg_name_cs',
             ],
         ],
     ],
@@ -51,7 +51,7 @@ return [
         'tableName' => 'static_territories',
         'properties' => [
             'nameCs' => [
-                'fieldName' => 'cu_name_cs',
+                'fieldName' => 'tr_name_cs',
             ],
         ],
     ],


### PR DESCRIPTION
Reference correct fieldnames in exbase persistance class for language and territory