### PR TITLE
[BUGFIX] Prevent empty values

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,5 +1,5 @@
 CREATE TABLE static_countries (
-  cn_short_cs varchar(50) DEFAULT '' NOT NULL
+  cn_short_cs varchar(60) DEFAULT '' NOT NULL
 );
 
 CREATE TABLE static_currencies (

--- a/ext_tables_static+adt.sql
+++ b/ext_tables_static+adt.sql
@@ -250,3 +250,4 @@ UPDATE static_countries SET cn_short_cs='Bonaire, Svatý Eustach a Saba' WHERE c
 UPDATE static_countries SET cn_short_cs='Curaçao' WHERE cn_iso_2='CW';
 UPDATE static_countries SET cn_short_cs='Svatý Martin' WHERE cn_iso_2='SX';
 UPDATE static_countries SET cn_short_cs='Jižní Súdán' WHERE cn_iso_2='SS';
+UPDATE static_countries SET cn_short_cs='Kosovo' WHERE cn_iso_2='XK';


### PR DESCRIPTION
Values for Hongkong and Macao are to long for the current field size.